### PR TITLE
Add a setting to draw the 3D world at higher detail

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,22 @@ orange crosshair art. The selected hue applies to both the original four-piece
 OBJ reticle and its Super FX cockpit triangles while damaged-wing indicators
 remain red.
 
+`RENDER SCALE` rasterizes the Super FX world layer from 1x up to 10x the source
+raster. Projection, face visibility, screen clipping, and BSP order are all
+computed on the original grid at every setting, so the geometry drawn is
+identical and scale-independent; only scan conversion follows the scale,
+resolving the same polygon edges and lines with finer steps. Cartridge HUD,
+sprites, backgrounds, and text keep their authored resolution. Scan conversion
+and presentation run on the CPU, so higher scales cost frame time and memory
+and the usable ceiling depends on the machine. As one reference point, a
+desktop test on the 4:3 raster held 60 FPS through 5x and about 30 FPS at 10x.
+
+`ANTI-ALIASING` and the surface-driven effects (`ENHANCED GRAPHICS`,
+`SMOOTH POLYS`, `RTX LIGHTING`) run on the scaled raster as well, so they
+resolve polygon edges at the selected scale instead of the source grid. Their
+cost grows with it, and the surface samples the last three read are only
+allocated while one of them is on.
+
 `CUSTOMIZE SCREEN` opens a mouse-driven captured native-gameplay HUD preview
 using the game's actual HUD artwork. Lives, Shield, Bombs/Boost, Comms, and the
 Boss Health bar can each be dragged independently; `RESET` (or Y) restores the

--- a/include/starfox/app/runtime_input.hpp
+++ b/include/starfox/app/runtime_input.hpp
@@ -93,6 +93,7 @@ struct PregameSettings {
     bool rumble{true};
     std::uint8_t crosshair_colour{};
     std::uint8_t experience{};
+    std::uint8_t render_scale{};
 
     [[nodiscard]] bool operator==(const PregameSettings&) const = default;
 };

--- a/include/starfox/render/framebuffer.hpp
+++ b/include/starfox/render/framebuffer.hpp
@@ -11,20 +11,48 @@ namespace starfox::render {
 
 struct Rgba8;
 
+// Pixels are stored at the render scale while every cartridge-authored pass
+// keeps addressing the source raster: a draw scale of S expands one logical
+// write into an SxS block, so 2D art stays pixel-exact. Scan conversion drops
+// the scale to 1 and writes single pixels across the full stored extent.
 class Framebuffer {
 public:
-    Framebuffer(std::uint32_t width, std::uint32_t height)
-        : width_(width), height_(height), pixels_(static_cast<std::size_t>(width) * height) {}
+    Framebuffer(std::uint32_t width, std::uint32_t height,
+        std::uint32_t draw_scale = 1U)
+        : stored_width_(width * draw_scale),
+          stored_height_(height * draw_scale),
+          draw_scale_(draw_scale),
+          pixels_(static_cast<std::size_t>(stored_width_) * stored_height_) {}
 
-    [[nodiscard]] std::uint32_t width() const noexcept { return width_; }
-    [[nodiscard]] std::uint32_t height() const noexcept { return height_; }
+    [[nodiscard]] std::uint32_t width() const noexcept {
+        return stored_width_ / draw_scale_;
+    }
+    [[nodiscard]] std::uint32_t height() const noexcept {
+        return stored_height_ / draw_scale_;
+    }
+    [[nodiscard]] std::uint32_t stored_width() const noexcept {
+        return stored_width_;
+    }
+    [[nodiscard]] std::uint32_t stored_height() const noexcept {
+        return stored_height_;
+    }
+    [[nodiscard]] std::uint32_t draw_scale() const noexcept {
+        return draw_scale_;
+    }
+    // Repartitions the same storage between source-raster and stored extents.
+    void set_draw_scale(std::uint32_t draw_scale) noexcept {
+        draw_scale_ = draw_scale == 0U ? 1U : draw_scale;
+    }
     [[nodiscard]] const std::vector<std::uint8_t>& pixels() const noexcept { return pixels_; }
 
     void resize(std::uint32_t width, std::uint32_t height) {
-        if (width == width_ && height == height_) return;
-        width_ = width;
-        height_ = height;
-        pixels_.assign(static_cast<std::size_t>(width) * height, 0U);
+        const auto stored_width = width * draw_scale_;
+        const auto stored_height = height * draw_scale_;
+        if (stored_width == stored_width_ && stored_height == stored_height_) return;
+        stored_width_ = stored_width;
+        stored_height_ = stored_height;
+        pixels_.assign(
+            static_cast<std::size_t>(stored_width_) * stored_height_, 0U);
     }
 
     void clear(std::uint8_t colour = 0) noexcept {
@@ -32,20 +60,46 @@ public:
     }
 
     void set(std::int32_t x, std::int32_t y, std::uint8_t colour) noexcept {
-        if (x < 0 || y < 0 || x >= static_cast<std::int32_t>(width_)
-            || y >= static_cast<std::int32_t>(height_)) {
+        if (x < 0 || y < 0 || x >= static_cast<std::int32_t>(width())
+            || y >= static_cast<std::int32_t>(height())) {
             return;
         }
-        pixels_[static_cast<std::size_t>(y) * width_ + static_cast<std::size_t>(x)] = colour;
+        if (draw_scale_ == 1U) {
+            pixels_[static_cast<std::size_t>(y) * stored_width_
+                + static_cast<std::size_t>(x)] = colour;
+            return;
+        }
+        const auto origin_x = static_cast<std::uint32_t>(x) * draw_scale_;
+        const auto origin_y = static_cast<std::uint32_t>(y) * draw_scale_;
+        for (std::uint32_t row = 0; row < draw_scale_; ++row) {
+            const auto begin = pixels_.begin()
+                + static_cast<std::ptrdiff_t>(
+                    static_cast<std::size_t>(origin_y + row) * stored_width_
+                    + origin_x);
+            std::fill(begin, begin + draw_scale_, colour);
+        }
     }
 
     [[nodiscard]] std::uint8_t get(std::uint32_t x, std::uint32_t y) const noexcept {
-        return pixels_[static_cast<std::size_t>(y) * width_ + x];
+        return pixels_[
+            static_cast<std::size_t>(y * draw_scale_) * stored_width_
+            + x * draw_scale_];
+    }
+
+    void set_stored(std::uint32_t x, std::uint32_t y, std::uint8_t colour) noexcept {
+        if (x >= stored_width_ || y >= stored_height_) return;
+        pixels_[static_cast<std::size_t>(y) * stored_width_ + x] = colour;
+    }
+
+    [[nodiscard]] std::uint8_t get_stored(
+        std::uint32_t x, std::uint32_t y) const noexcept {
+        return pixels_[static_cast<std::size_t>(y) * stored_width_ + x];
     }
 
 private:
-    std::uint32_t width_{};
-    std::uint32_t height_{};
+    std::uint32_t stored_width_{};
+    std::uint32_t stored_height_{};
+    std::uint32_t draw_scale_{1U};
     std::vector<std::uint8_t> pixels_;
 };
 

--- a/include/starfox/render/software_renderer.hpp
+++ b/include/starfox/render/software_renderer.hpp
@@ -86,6 +86,10 @@ struct RenderSettings {
     bool backface_culling{false};
     std::uint8_t background_colour{};
     std::uint8_t colour_index_base{};
+    // Supersampling factor applied to scan conversion only. Projection,
+    // visibility and clipping stay on the source raster at every setting, so
+    // the geometry drawn is identical and scale-independent.
+    std::uint32_t render_scale{1U};
 };
 
 // Presentation metadata for a host-rendered Super FX surface. The indexed

--- a/include/starfox/simulation/game_simulation.hpp
+++ b/include/starfox/simulation/game_simulation.hpp
@@ -62,6 +62,23 @@ enum class DisplayMode {
     super_ultrawide_32_9,
 };
 
+// Internal supersampling of the host-rendered 3D layer. Cartridge 2D art is
+// unaffected and keeps its source raster.
+enum class RenderScale : std::uint8_t {
+    scale_1x,
+    scale_2x,
+    scale_3x,
+    scale_4x,
+    scale_5x,
+    scale_6x,
+    scale_7x,
+    scale_8x,
+    scale_9x,
+    scale_10x,
+};
+
+inline constexpr std::size_t render_scale_count = 10U;
+
 enum class PregamePage {
     main,
     options,
@@ -277,6 +294,12 @@ public:
     }
     void set_crosshair_colour(CrosshairColour colour) noexcept {
         crosshair_colour_ = colour;
+    }
+    [[nodiscard]] RenderScale render_scale() const noexcept {
+        return render_scale_;
+    }
+    void set_render_scale(RenderScale scale) noexcept {
+        render_scale_ = scale;
     }
     void set_secondary_inputs(
         std::span<const input::TickInput> controllers) noexcept;
@@ -836,6 +859,7 @@ private:
     bool msu1_available_{true};
     bool rumble_{true};
     CrosshairColour crosshair_colour_{CrosshairColour::green};
+    RenderScale render_scale_{RenderScale::scale_1x};
     bool planet_travel_complete_{};
     bool planet_arrival_confirmation_required_{};
     std::uint8_t stage_percentage_{};

--- a/src/app/runtime_input.cpp
+++ b/src/app/runtime_input.cpp
@@ -7,6 +7,8 @@
 #include <filesystem>
 #include <fstream>
 #include <sstream>
+#include <string>
+#include <string_view>
 #include <vector>
 
 namespace starfox::app {
@@ -96,6 +98,11 @@ int gamepad_preference(SDL_JoystickID identifier) {
     }
     return score;
 }
+
+// Pre-game settings file format. Bump kPregameRevision when a field is added;
+// the reader accepts every revision up to it.
+constexpr std::string_view kPregameTag{"SFE_PREGAME_V"};
+constexpr int kPregameRevision = 7;
 
 std::filesystem::path settings_path() {
     char* preference_path = SDL_GetPrefPath("StarFoxEnhanced", "StarFoxEnhanced");
@@ -447,24 +454,28 @@ bool load_pregame_settings(
     if (path.empty()) return false;
     std::ifstream input{path};
     std::string version;
-    if (!(input >> version)
-        || (version != "SFE_PREGAME_V1" && version != "SFE_PREGAME_V2"
-            && version != "SFE_PREGAME_V3"
-            && version != "SFE_PREGAME_V4"
-            && version != "SFE_PREGAME_V5"
-            && version != "SFE_PREGAME_V6")) {
+    if (!(input >> version) || !version.starts_with(kPregameTag)) return false;
+    const auto digits = std::string_view{version}.substr(kPregameTag.size());
+    if (digits.empty() || !std::all_of(digits.begin(), digits.end(),
+            [](unsigned char character) {
+                return std::isdigit(character) != 0;
+            })) {
         return false;
     }
+    const auto revision = std::stoi(std::string{digits});
+    if (revision < 1 || revision > kPregameRevision) return false;
+
     auto loaded = PregameSettings{};
-    std::array<bool, 14> found{};
-    if (version != "SFE_PREGAME_V6") {
+    std::array<bool, 15> found{};
+    if (revision < 6) {
         found[12] = true;
         found[13] = true;
     }
-    found[6] = version == "SFE_PREGAME_V1";
-    if (version == "SFE_PREGAME_V1" || version == "SFE_PREGAME_V2") {
+    found[14] = revision < 7;
+    found[6] = revision == 1;
+    if (revision <= 2) {
         std::fill(found.begin() + 7, found.end(), true);
-    } else if (version == "SFE_PREGAME_V3") {
+    } else if (revision == 3) {
         // V3's combined Enhanced option already included polygon edge
         // smoothing. Preserve that visible result when splitting it into a
         // dedicated V4 choice.
@@ -491,9 +502,7 @@ bool load_pregame_settings(
             found[4] = value == 0 || value == 1;
         } else if (name == "ANTI_ALIASING") {
             loaded.anti_aliasing = static_cast<std::uint8_t>(value);
-            found[7] = value >= 0 && value <= (
-                version == "SFE_PREGAME_V5" || version == "SFE_PREGAME_V6"
-                ? 3 : 1);
+            found[7] = value >= 0 && value <= (revision >= 5 ? 3 : 1);
         } else if (name == "ENHANCED_GRAPHICS") {
             loaded.enhanced_graphics = value != 0;
             found[8] = value == 0 || value == 1;
@@ -518,15 +527,17 @@ bool load_pregame_settings(
         } else if (name == "EXPERIENCE") {
             loaded.experience = static_cast<std::uint8_t>(value);
             found[6] = value >= 0 && value <= 1;
+        } else if (name == "RENDER_SCALE") {
+            loaded.render_scale = static_cast<std::uint8_t>(value);
+            found[14] = value >= 0 && value <= 9;
         }
     }
     if (!std::all_of(found.begin(), found.end(),
             [](bool value) { return value; })) return false;
-    if (version == "SFE_PREGAME_V3") {
+    if (revision == 3) {
         loaded.smooth_polys = loaded.enhanced_graphics;
     }
-    if (version != "SFE_PREGAME_V5" && version != "SFE_PREGAME_V6"
-        && loaded.anti_aliasing != 0U) {
+    if (revision < 5 && loaded.anti_aliasing != 0U) {
         // The original ON setting used what is now the medium FXAA kernel.
         loaded.anti_aliasing = 2U;
     }
@@ -540,7 +551,7 @@ bool save_pregame_settings(
     if (path.empty() || settings.timing_mode > 1U
         || settings.display_mode > 4U || settings.crosshair_colour > 7U
         || settings.anti_aliasing > 3U
-        || settings.experience > 1U) {
+        || settings.experience > 1U || settings.render_scale > 9U) {
         return false;
     }
     constexpr std::array<std::uint16_t, 8> valid_fps{
@@ -552,7 +563,7 @@ bool save_pregame_settings(
     if (error) return false;
     std::ofstream output{path, std::ios::trunc};
     if (!output) return false;
-    output << "SFE_PREGAME_V6\n"
+    output << kPregameTag << kPregameRevision << '\n'
            << "EXPERIENCE " << static_cast<unsigned>(settings.experience) << '\n'
            << "TIMING_MODE " << static_cast<unsigned>(settings.timing_mode) << '\n'
            << "PRESENTATION_FPS " << settings.presentation_fps << '\n'
@@ -572,7 +583,9 @@ bool save_pregame_settings(
            << static_cast<unsigned>(settings.msu1_music) << '\n'
            << "RUMBLE " << static_cast<unsigned>(settings.rumble) << '\n'
            << "CROSSHAIR_COLOUR "
-           << static_cast<unsigned>(settings.crosshair_colour) << '\n';
+           << static_cast<unsigned>(settings.crosshair_colour) << '\n'
+           << "RENDER_SCALE "
+           << static_cast<unsigned>(settings.render_scale) << '\n';
     return static_cast<bool>(output);
 }
 

--- a/src/app/starfox_pc.cpp
+++ b/src/app/starfox_pc.cpp
@@ -166,6 +166,37 @@ std::string_view display_profile_name(
     }
 }
 
+constexpr std::array<std::string_view,
+    starfox::simulation::render_scale_count> render_scale_names{{
+    "1X  NATIVE",
+    "2X",
+    "3X",
+    "4X",
+    "5X",
+    "6X",
+    "7X",
+    "8X",
+    "9X",
+    "10X",
+}};
+
+std::uint32_t render_scale_index(
+    starfox::simulation::RenderScale scale) noexcept {
+    return std::min(static_cast<std::uint32_t>(scale),
+        static_cast<std::uint32_t>(
+            starfox::simulation::render_scale_count - 1U));
+}
+
+std::uint32_t render_scale_factor(
+    starfox::simulation::RenderScale scale) noexcept {
+    return render_scale_index(scale) + 1U;
+}
+
+std::string_view render_scale_name(
+    starfox::simulation::RenderScale scale) noexcept {
+    return render_scale_names[render_scale_index(scale)];
+}
+
 std::string_view crosshair_colour_name(
     starfox::simulation::CrosshairColour colour) noexcept {
     switch (colour) {
@@ -694,9 +725,24 @@ public:
         std::span<const starfox::render::Rgba8> palette,
         const starfox::simulation::CircleEffectState& circle,
         const PresentationEffects& effects = {}) {
-        ensure_dimensions(framebuffer.width(), framebuffer.height());
+        window_scale_ = framebuffer.draw_scale();
+        ensure_dimensions(
+            framebuffer.stored_width(), framebuffer.stored_height());
         starfox::render::expand_rgba(framebuffer, rgba_, palette);
-        const auto composite_subtractive_overlay = [this, &framebuffer, palette](
+        // Presentation effects address the source raster. Apply each one to
+        // every stored pixel the render scale expanded that raster cell into.
+        const auto render_scale = framebuffer.draw_scale();
+        const auto stored_width =
+            static_cast<std::size_t>(framebuffer.stored_width());
+        const auto stored_pixel = [render_scale, stored_width](
+                                      std::size_t x, std::size_t y,
+                                      std::uint32_t column, std::uint32_t row) {
+            return ((y * render_scale + row) * stored_width
+                + x * render_scale + column) * 4U;
+        };
+        const auto composite_subtractive_overlay = [this, &framebuffer, palette,
+                                                       &stored_pixel,
+                                                       render_scale](
                                                        const auto* overlay_pointer,
                                                        std::uint8_t requested_brightness) {
             if (overlay_pointer == nullptr) return;
@@ -707,8 +753,6 @@ public:
                 for (std::uint32_t x = 0; x < framebuffer.width(); ++x) {
                     const auto colour = overlay.get(x, y);
                     if (colour == 0U || colour >= palette.size()) continue;
-                    const auto pixel = (static_cast<std::size_t>(y)
-                        * framebuffer.width() + x) * 4U;
                     const auto& source = palette[colour];
                     // PLANETS.ASM fades BG2 by subtracting a fixed white
                     // colour through CGADSUB. Multiplying RGB made the
@@ -724,10 +768,17 @@ public:
                         return static_cast<std::uint8_t>(
                             (result_five << 3U) | (result_five >> 2U));
                     };
+for (std::uint32_t block_row = 0; block_row < render_scale;
+                         ++block_row) {
+                    for (std::uint32_t block_column = 0;
+                         block_column < render_scale; ++block_column) {
+                    const auto pixel = stored_pixel(x, y, block_column, block_row);
                     rgba_[pixel] = fade_component(source.r);
                     rgba_[pixel + 1U] = fade_component(source.g);
                     rgba_[pixel + 2U] = fade_component(source.b);
                     rgba_[pixel + 3U] = source.a;
+                    }
+                    }
                 }
             }
         };
@@ -772,11 +823,18 @@ public:
                             continue;
                         }
                     }
-                    const auto pixel = (static_cast<std::size_t>(y)
-                        * framebuffer.width() + static_cast<std::size_t>(x))
-                        * 4U;
-                    subtract_fixed_white(pixel,
-                        effects.background_fixed_white_subtract);
+                    for (std::uint32_t block_row = 0;
+                         block_row < render_scale; ++block_row) {
+                        for (std::uint32_t block_column = 0;
+                             block_column < render_scale; ++block_column) {
+                            const auto pixel = stored_pixel(
+                                static_cast<std::size_t>(x),
+                                static_cast<std::size_t>(y),
+                                block_column, block_row);
+                            subtract_fixed_white(pixel,
+                                effects.background_fixed_white_subtract);
+                        }
+                    }
                 }
             }
         }
@@ -814,9 +872,13 @@ public:
                     // not washed into the expanding disk.
                     if (source_index >= 128U
                         && (circle.affected_layers & 0x10U) == 0U) continue;
-                    const auto pixel = (static_cast<std::size_t>(y)
-                        * framebuffer.width()
-                        + static_cast<std::size_t>(x)) * 4U;
+for (std::uint32_t block_row = 0; block_row < render_scale;
+                         ++block_row) {
+                    for (std::uint32_t block_column = 0;
+                         block_column < render_scale; ++block_column) {
+                    const auto pixel = stored_pixel(
+                        static_cast<std::size_t>(x),
+                        static_cast<std::size_t>(y), block_column, block_row);
                     for (std::size_t component = 0; component < 3U; ++component) {
                         const auto main = static_cast<std::int32_t>(
                             (static_cast<std::uint32_t>(rgba_[pixel + component])
@@ -827,6 +889,8 @@ public:
                         value = std::clamp(value, 0, 31);
                         rgba_[pixel + component] = static_cast<std::uint8_t>(
                             (value << 3U) | (value >> 2U));
+                    }
+                    }
                     }
                 }
             }
@@ -840,10 +904,18 @@ public:
                         && x <= effects.planet.isolate_right
                         && y >= effects.planet.isolate_top
                         && y <= effects.planet.isolate_bottom) continue;
-                    const auto pixel = (static_cast<std::size_t>(y)
-                        * framebuffer.width() + static_cast<std::size_t>(x)) * 4U;
-                    subtract_fixed_white(
-                        pixel, effects.planet.isolate_amount);
+                    for (std::uint32_t block_row = 0;
+                         block_row < render_scale; ++block_row) {
+                        for (std::uint32_t block_column = 0;
+                             block_column < render_scale; ++block_column) {
+                            const auto pixel = stored_pixel(
+                                static_cast<std::size_t>(x),
+                                static_cast<std::size_t>(y),
+                                block_column, block_row);
+                            subtract_fixed_white(
+                                pixel, effects.planet.isolate_amount);
+                        }
+                    }
                 }
             }
         }
@@ -904,13 +976,19 @@ public:
                     default: masked = window_1 || window_2; break; // OR
                     }
                     if (!masked) continue;
-                    const auto pixel = (static_cast<std::size_t>(y)
-                        * framebuffer.width() + static_cast<std::size_t>(x))
-                        * 4U;
+for (std::uint32_t block_row = 0; block_row < render_scale;
+                         ++block_row) {
+                    for (std::uint32_t block_column = 0;
+                         block_column < render_scale; ++block_column) {
+                    const auto pixel = stored_pixel(
+                        static_cast<std::size_t>(x),
+                        static_cast<std::size_t>(y), block_column, block_row);
                     rgba_[pixel] = 0U;
                     rgba_[pixel + 1U] = 0U;
                     rgba_[pixel + 2U] = 0U;
                     rgba_[pixel + 3U] = 255U;
+                    }
+                    }
                 }
             }
         }
@@ -924,12 +1002,19 @@ public:
                 for (std::int32_t x = 0;
                      x < static_cast<std::int32_t>(framebuffer.width()); ++x) {
                     if (x >= left && x < right) continue;
-                    const auto pixel = (static_cast<std::size_t>(y)
-                        * framebuffer.width() + static_cast<std::size_t>(x)) * 4U;
+for (std::uint32_t block_row = 0; block_row < render_scale;
+                         ++block_row) {
+                    for (std::uint32_t block_column = 0;
+                         block_column < render_scale; ++block_column) {
+                    const auto pixel = stored_pixel(
+                        static_cast<std::size_t>(x),
+                        static_cast<std::size_t>(y), block_column, block_row);
                     rgba_[pixel] = 0U;
                     rgba_[pixel + 1U] = 0U;
                     rgba_[pixel + 2U] = 0U;
                     rgba_[pixel + 3U] = 255U;
+                    }
+                    }
                 }
             }
         }
@@ -938,7 +1023,8 @@ public:
         if (rtx_lighting_) apply_rtx_lighting(framebuffer, effects);
         if (effects.host_overlay != nullptr) {
             const auto& overlay = *effects.host_overlay;
-            const auto paint = [this, &framebuffer](
+            const auto paint = [this, &framebuffer, &stored_pixel,
+                                   render_scale](
                                    std::int32_t x, std::int32_t y,
                                    std::uint8_t value) {
                 if (x < 0 || y < 0
@@ -946,12 +1032,18 @@ public:
                     || y >= static_cast<std::int32_t>(framebuffer.height())) {
                     return;
                 }
-                const auto pixel = (static_cast<std::size_t>(y)
-                    * framebuffer.width() + static_cast<std::size_t>(x)) * 4U;
+                for (std::uint32_t block_row = 0; block_row < render_scale;
+                     ++block_row) {
+                for (std::uint32_t block_column = 0;
+                     block_column < render_scale; ++block_column) {
+                const auto pixel = stored_pixel(static_cast<std::size_t>(x),
+                    static_cast<std::size_t>(y), block_column, block_row);
                 rgba_[pixel] = value;
                 rgba_[pixel + 1U] = value;
                 rgba_[pixel + 2U] = value;
                 rgba_[pixel + 3U] = 255U;
+                }
+                }
             };
             // Draw a one-pixel black shadow first, then opaque white glyphs.
             // This host diagnostic remains legible through every cartridge
@@ -1014,7 +1106,8 @@ public:
         if (anti_aliasing_ != starfox::simulation::AntiAliasingMode::off) {
             apply_fxaa(anti_aliasing_);
         }
-        present_rgba_pixels(framebuffer.width(), framebuffer.height(), rgba_);
+        present_rgba_pixels(
+            framebuffer.stored_width(), framebuffer.stored_height(), rgba_);
     }
 
     void present_rgba(std::uint32_t width, std::uint32_t height,
@@ -1121,6 +1214,10 @@ private:
             >> 8U);
     }
 
+    // Coordinates here are stored-raster, not source-raster. Scan conversion
+    // writes both the indexed pixel and its surface sample at the render
+    // scale, so the effect passes address them the same way and resolve
+    // polygon edges at whatever scale the frame was drawn at.
     [[nodiscard]] static const starfox::render::SurfaceSample* model_surface_at(
         const starfox::render::Framebuffer& framebuffer,
         const PresentationEffects& effects,
@@ -1135,8 +1232,8 @@ private:
             || local_y >= static_cast<std::int32_t>(
                 effects.model_surfaces->height())
             || x < 0 || y < 0
-            || x >= static_cast<std::int32_t>(framebuffer.width())
-            || y >= static_cast<std::int32_t>(framebuffer.height())) {
+            || x >= static_cast<std::int32_t>(framebuffer.stored_width())
+            || y >= static_cast<std::int32_t>(framebuffer.stored_height())) {
             return nullptr;
         }
         const auto& sample = effects.model_surfaces->get(
@@ -1145,7 +1242,7 @@ private:
         // A later particle, HUD element, or cartridge layer may cover the
         // polygon. Only shade the surface if its indexed colour still owns the
         // final composite pixel.
-        if (!sample.valid || framebuffer.get(
+        if (!sample.valid || framebuffer.get_stored(
                 static_cast<std::uint32_t>(x),
                 static_cast<std::uint32_t>(y)) != sample.palette_index) {
             return nullptr;
@@ -1192,20 +1289,21 @@ private:
         const PresentationEffects& effects) {
         if (effects.model_surfaces == nullptr
             || effects.model_surfaces->empty()
-            || framebuffer.width() < 3U || framebuffer.height() < 3U) {
+            || framebuffer.stored_width() < 3U
+            || framebuffer.stored_height() < 3U) {
             return;
         }
-        const auto width = static_cast<std::size_t>(framebuffer.width());
+        const auto width = static_cast<std::size_t>(framebuffer.stored_width());
         const auto first_x = std::max(1, effects.model_surface_x
             + static_cast<std::int32_t>(effects.model_surfaces->minimum_x()) - 1);
         const auto first_y = std::max(1, effects.model_surface_y
             + static_cast<std::int32_t>(effects.model_surfaces->minimum_y()) - 1);
         const auto last_x = std::min(
-            static_cast<std::int32_t>(framebuffer.width()) - 1,
+            static_cast<std::int32_t>(framebuffer.stored_width()) - 1,
             effects.model_surface_x
                 + static_cast<std::int32_t>(effects.model_surfaces->maximum_x()) + 1);
         const auto last_y = std::min(
-            static_cast<std::int32_t>(framebuffer.height()) - 1,
+            static_cast<std::int32_t>(framebuffer.stored_height()) - 1,
             effects.model_surface_y
                 + static_cast<std::int32_t>(effects.model_surfaces->maximum_y()) + 1);
         capture_effect_source_region(
@@ -1272,20 +1370,21 @@ private:
         const PresentationEffects& effects) {
         if (effects.model_surfaces == nullptr
             || effects.model_surfaces->empty()
-            || framebuffer.width() < 3U || framebuffer.height() < 3U) {
+            || framebuffer.stored_width() < 3U
+            || framebuffer.stored_height() < 3U) {
             return;
         }
-        const auto width = static_cast<std::size_t>(framebuffer.width());
+        const auto width = static_cast<std::size_t>(framebuffer.stored_width());
         const auto first_x = std::max(1, effects.model_surface_x
             + static_cast<std::int32_t>(effects.model_surfaces->minimum_x()) - 1);
         const auto first_y = std::max(1, effects.model_surface_y
             + static_cast<std::int32_t>(effects.model_surfaces->minimum_y()) - 1);
         const auto last_x = std::min(
-            static_cast<std::int32_t>(framebuffer.width()) - 1,
+            static_cast<std::int32_t>(framebuffer.stored_width()) - 1,
             effects.model_surface_x
                 + static_cast<std::int32_t>(effects.model_surfaces->maximum_x()) + 1);
         const auto last_y = std::min(
-            static_cast<std::int32_t>(framebuffer.height()) - 1,
+            static_cast<std::int32_t>(framebuffer.stored_height()) - 1,
             effects.model_surface_y
                 + static_cast<std::int32_t>(effects.model_surfaces->maximum_y()) + 1);
         capture_effect_source_region(
@@ -1394,20 +1493,21 @@ private:
         const PresentationEffects& effects) {
         if (effects.model_surfaces == nullptr
             || effects.model_surfaces->empty()
-            || framebuffer.width() < 3U || framebuffer.height() < 3U) {
+            || framebuffer.stored_width() < 3U
+            || framebuffer.stored_height() < 3U) {
             return;
         }
-        const auto width = static_cast<std::size_t>(framebuffer.width());
+        const auto width = static_cast<std::size_t>(framebuffer.stored_width());
         const auto first_x = std::max(1, effects.model_surface_x
             + static_cast<std::int32_t>(effects.model_surfaces->minimum_x()));
         const auto first_y = std::max(1, effects.model_surface_y
             + static_cast<std::int32_t>(effects.model_surfaces->minimum_y()));
         const auto last_x = std::min(
-            static_cast<std::int32_t>(framebuffer.width()) - 1,
+            static_cast<std::int32_t>(framebuffer.stored_width()) - 1,
             effects.model_surface_x
                 + static_cast<std::int32_t>(effects.model_surfaces->maximum_x()));
         const auto last_y = std::min(
-            static_cast<std::int32_t>(framebuffer.height()) - 1,
+            static_cast<std::int32_t>(framebuffer.stored_height()) - 1,
             effects.model_surface_y
                 + static_cast<std::int32_t>(effects.model_surfaces->maximum_y()));
         // Camera-space key light from above-left, a cool frontal fill, and the
@@ -1555,11 +1655,13 @@ private:
     }
 
     void set_windowed_size(std::uint32_t width, std::uint32_t height) noexcept {
-        const auto integer_scale = width <= snes_width
-            ? 4U : (width <= widescreen_16_9_width ? 3U : 2U);
+        const auto raster_width = width / window_scale_;
+        const auto raster_height = height / window_scale_;
+        const auto integer_scale = raster_width <= snes_width
+            ? 4U : (raster_width <= widescreen_16_9_width ? 3U : 2U);
         SDL_SetWindowSize(window_,
-            static_cast<int>(width * integer_scale),
-            static_cast<int>(height * integer_scale));
+            static_cast<int>(raster_width * integer_scale),
+            static_cast<int>(raster_height * integer_scale));
     }
 
     void present_rgba_pixels(std::uint32_t width, std::uint32_t height,
@@ -1599,6 +1701,7 @@ private:
         texture_height_ = height;
     }
 
+    std::uint32_t window_scale_{1U};
     SDL_Window* window_{};
     SDL_Renderer* renderer_{};
     SDL_Texture* texture_{};
@@ -2348,6 +2451,7 @@ int main(int argc, char** argv) {
                 game.rumble(),
                 static_cast<std::uint8_t>(game.crosshair_colour()),
                 static_cast<std::uint8_t>(game.experience()),
+                static_cast<std::uint8_t>(game.render_scale()),
             };
         };
         {
@@ -2419,6 +2523,18 @@ int main(int argc, char** argv) {
             game.set_crosshair_colour(
                 static_cast<starfox::simulation::CrosshairColour>(
                     saved_pregame.crosshair_colour));
+            game.set_render_scale(static_cast<starfox::simulation::RenderScale>(
+                saved_pregame.render_scale));
+            if (const auto* forced_scale = std::getenv(
+                    "STARFOX_TEST_RENDER_SCALE")) {
+                const auto factor = std::atoi(forced_scale);
+                if (factor >= 1 && factor <= static_cast<int>(
+                        starfox::simulation::render_scale_count)) {
+                    game.set_render_scale(
+                        static_cast<starfox::simulation::RenderScale>(
+                            factor - 1));
+                }
+            }
             game.set_experience(active_experience);
             if (hud_editor_preview) {
                 // Build the editor's static reference image from a genuine
@@ -2723,19 +2839,21 @@ int main(int argc, char** argv) {
         // Widescreen grows the scene symmetrically to 400x224 while HUD and
         // dialogue retain their original 224x192 coordinates in a centred
         // inset layer.
-        starfox::render::Framebuffer framebuffer{snes_width, snes_height};
+        auto render_scale = render_scale_factor(game.render_scale());
+        starfox::render::Framebuffer framebuffer{
+            snes_width, snes_height, render_scale};
         starfox::render::Framebuffer superfx_frame{
-            snes_width, superfx_height};
+            snes_width, superfx_height, render_scale};
         starfox::render::SurfaceBuffer superfx_surfaces{
-            snes_width, superfx_height};
+            snes_width * render_scale, superfx_height * render_scale};
         starfox::render::Framebuffer superfx_ui{
-            superfx_ui_width, superfx_height};
+            superfx_ui_width, superfx_height, render_scale};
         starfox::render::Framebuffer comms_hud{
-            superfx_ui_width, superfx_height};
+            superfx_ui_width, superfx_height, render_scale};
         starfox::render::Framebuffer superfx_hud{
-            snes_width, superfx_height};
+            snes_width, superfx_height, render_scale};
         starfox::render::Framebuffer controls_player_layer{
-            snes_width, superfx_height};
+            snes_width, superfx_height, render_scale};
         starfox::render::Framebuffer native_ex_overlay{
             snes_width, snes_height};
         starfox::render::Framebuffer planet_overlay{snes_width, snes_height};
@@ -2745,7 +2863,8 @@ int main(int argc, char** argv) {
         starfox::render::Framebuffer exit_confirmation_overlay{112U, 40U};
         starfox::render::RenderSettings render_settings;
         render_settings.colour_index_base = 7U * 16U;
-        const starfox::render::SoftwareRenderer renderer{render_settings};
+        render_settings.render_scale = render_scale;
+        starfox::render::SoftwareRenderer renderer{render_settings};
         const starfox::render::ParticleRenderer particle_renderer;
         const starfox::render::ScaledTextRenderer text_renderer{rom, symbols};
         const starfox::render::BackgroundRenderer background_renderer;
@@ -3520,7 +3639,7 @@ int main(int argc, char** argv) {
                                    == starfox::simulation::GameFlowState::pregame_menu
                                && game.pregame_page()
                                    == starfox::simulation::PregamePage::options
-                               && game.pregame_selection() == 3U
+                               && game.pregame_selection() == 4U
                                && (controls.pressed
                                    & (starfox::input::a
                                       | starfox::input::select)) != 0U) {
@@ -3656,12 +3775,30 @@ int main(int argc, char** argv) {
                 ? snes_height : superfx_height;
             const auto scene_offset_y = extend_scene_vertical
                 ? 0 : superfx_offset_y;
+            render_scale = render_scale_factor(game.render_scale());
+            if (render_settings.render_scale != render_scale) {
+                render_settings.render_scale = render_scale;
+                renderer = starfox::render::SoftwareRenderer{render_settings};
+            }
+            for (auto* layer : {&framebuffer, &superfx_frame, &superfx_hud,
+                     &controls_player_layer, &superfx_ui, &comms_hud}) {
+                layer->set_draw_scale(render_scale);
+            }
             framebuffer.resize(display_width, snes_height);
             superfx_frame.resize(display_width, scene_height);
-            superfx_surfaces.resize(display_width, scene_height);
+            // Surface samples parallel the stored 3D raster, so at a high
+            // render scale this is the largest per-frame allocation. Only the
+            // three surface-driven effects read it; leave it empty otherwise.
+            const auto surface_effects = game.enhanced_graphics()
+                || game.smooth_polys() || game.rtx_lighting();
+            superfx_surfaces.resize(
+                surface_effects ? display_width * render_scale : 0U,
+                surface_effects ? scene_height * render_scale : 0U);
             superfx_hud.resize(display_width, superfx_height);
             controls_player_layer.resize(display_width, superfx_height);
             native_ex_overlay.resize(display_width, snes_height);
+            superfx_ui.resize(superfx_ui_width, superfx_height);
+            comms_hud.resize(superfx_ui_width, superfx_height);
             planet_overlay.resize(display_width, snes_height);
             planet_text_overlay.resize(display_width, snes_height);
             // A paused cartridge presents one completed source frame. Do not
@@ -4932,18 +5069,23 @@ int main(int argc, char** argv) {
                             ? std::string_view{"ON"} : std::string_view{"OFF"};
                         const auto crosshair = crosshair_colour_name(
                             game.crosshair_colour());
-                        draw_row("GOD MODE", god_value, 56,
+                        constexpr std::array<std::int32_t, 6> option_y{
+                            56, 76, 96, 116, 136, 162};
+                        draw_row("GOD MODE", god_value, option_y[0],
                             game.pregame_selection() == 0U);
-                        draw_row("ON-SCREEN FPS", fps_value, 76,
+                        draw_row("ON-SCREEN FPS", fps_value, option_y[1],
                             game.pregame_selection() == 1U);
-                        draw_row("CROSSHAIR COLOR", crosshair, 96,
+                        draw_row("CROSSHAIR COLOR", crosshair, option_y[2],
                             game.pregame_selection() == 2U);
-                        draw_row("CUSTOMIZE SCREEN", "A  OPEN", 116,
-                            game.pregame_selection() == 3U);
-                        draw_row("BACK", "", 146,
+                        draw_row("RENDER SCALE",
+                            render_scale_name(game.render_scale()),
+                            option_y[3], game.pregame_selection() == 3U);
+                        draw_row("CUSTOMIZE SCREEN", "A  OPEN", option_y[4],
                             game.pregame_selection() == 4U);
-                        constexpr std::array<std::int32_t, 5> cursor_y{
-                            59, 79, 99, 119, 149};
+                        draw_row("BACK", "", option_y[5],
+                            game.pregame_selection() == 5U);
+                        constexpr std::array<std::int32_t, 6> cursor_y{
+                            59, 79, 99, 119, 139, 165};
                         draw_cursor(cursor_y[game.pregame_selection()]);
                         draw_centred("A/LEFT/RIGHT  CHANGE", 180, 13U);
                         draw_centred("B  BACK", 194, 13U);
@@ -5188,7 +5330,8 @@ int main(int argc, char** argv) {
                 game.enhanced_graphics() || game.smooth_polys()
                         || game.rtx_lighting()
                 ? &superfx_surfaces : nullptr;
-            presentation_effects.model_surface_y = scene_offset_y;
+            presentation_effects.model_surface_y =
+                scene_offset_y * static_cast<std::int32_t>(render_scale);
             presentation_effects.background_fixed_white_subtract =
                 game.game_over_background_subtract();
             if (presentation_effects.background_fixed_white_subtract != 0U) {
@@ -5219,8 +5362,8 @@ int main(int argc, char** argv) {
             }
             window.present(
                 framebuffer, palette, circle, presentation_effects);
-            presentation_history.record(
-                framebuffer.width(), framebuffer.height(), window.rgba());
+            presentation_history.record(framebuffer.stored_width(),
+                framebuffer.stored_height(), window.rgba());
             if (advance_frozen_frame) {
                 window.set_frame_debug_status(true,
                     presentation_history.cursor(),

--- a/src/render/framebuffer.cpp
+++ b/src/render/framebuffer.cpp
@@ -63,11 +63,38 @@ void composite_transparent_layer(const Framebuffer& source,
                     continue;
                 }
             }
-            const auto colour = source.get(
-                static_cast<std::uint32_t>(source_x),
-                static_cast<std::uint32_t>(source_y));
-            if (colour != 0U) {
-                destination.set(destination_x, destination_y, colour);
+            // Clipping and mosaic stay on the source raster grid, matching
+            // the PPU. Only the transfer itself runs at the stored scale so a
+            // higher-resolution 3D layer keeps its detail through the pass.
+            const auto scale = source.draw_scale();
+            if (scale == 1U && destination.draw_scale() == 1U) {
+                const auto colour = source.get(
+                    static_cast<std::uint32_t>(source_x),
+                    static_cast<std::uint32_t>(source_y));
+                if (colour != 0U) {
+                    destination.set(destination_x, destination_y, colour);
+                }
+                continue;
+            }
+            if (destination_x < 0 || destination_y < 0) continue;
+            const auto source_origin_x =
+                static_cast<std::uint32_t>(source_x) * scale;
+            const auto source_origin_y =
+                static_cast<std::uint32_t>(source_y) * scale;
+            const auto destination_origin_x =
+                static_cast<std::uint32_t>(destination_x)
+                * destination.draw_scale();
+            const auto destination_origin_y =
+                static_cast<std::uint32_t>(destination_y)
+                * destination.draw_scale();
+            for (std::uint32_t row = 0; row < scale; ++row) {
+                for (std::uint32_t column = 0; column < scale; ++column) {
+                    const auto colour = source.get_stored(
+                        source_origin_x + column, source_origin_y + row);
+                    if (colour == 0U) continue;
+                    destination.set_stored(destination_origin_x + column,
+                        destination_origin_y + row, colour);
+                }
             }
         }
     }

--- a/src/render/software_renderer.cpp
+++ b/src/render/software_renderer.cpp
@@ -306,6 +306,30 @@ std::vector<RasterVertex> clip_screen_edge(
     return output;
 }
 
+// Scan conversion is the only stage that follows the render scale. Projection,
+// visibility and clipping all stay on the source raster, so a scaled frame
+// resolves exactly the same geometry with finer scan lines.
+class StoredRasterScope {
+public:
+    StoredRasterScope(Framebuffer& target, std::uint32_t scale) noexcept
+        : target_(target), previous_(target.draw_scale()) {
+        if (scale > 1U) target_.set_draw_scale(1U);
+    }
+    ~StoredRasterScope() { target_.set_draw_scale(previous_); }
+    StoredRasterScope(const StoredRasterScope&) = delete;
+    StoredRasterScope& operator=(const StoredRasterScope&) = delete;
+
+private:
+    Framebuffer& target_;
+    std::uint32_t previous_;
+};
+
+void scale_to_stored(ScreenPoint& point, std::uint32_t scale) noexcept {
+    if (scale <= 1U) return;
+    point.x *= static_cast<double>(scale);
+    point.y *= static_cast<double>(scale);
+}
+
 std::vector<RasterVertex> clip_screen_polygon(
     std::vector<RasterVertex> polygon,
     const Framebuffer& target,
@@ -1498,6 +1522,10 @@ void SoftwareRenderer::draw(
                     const auto material = face_material(shape, shape.faces.front(),
                         pose.colour_frame, depth_band, light, pose,
                         next_colour_warp_word());
+                    const StoredRasterScope raster{
+                        target, settings_.render_scale};
+                    scale_to_stored(near_screen, settings_.render_scale);
+                    scale_to_stored(far_screen, settings_.render_scale);
                     draw_line(target, near_screen, far_screen, material.colour,
                         settings_.colour_index_base);
                 }
@@ -1685,6 +1713,9 @@ void SoftwareRenderer::draw(
                     polygon[0], polygon[1], target, pose.use_rotation_matrix)) {
                 continue;
             }
+            const StoredRasterScope raster{target, settings_.render_scale};
+            scale_to_stored(polygon[0], settings_.render_scale);
+            scale_to_stored(polygon[1], settings_.render_scale);
             draw_line(target, polygon[0], polygon[1], material.colour,
                 settings_.colour_index_base);
             continue;
@@ -1714,6 +1745,10 @@ void SoftwareRenderer::draw(
         raster_polygon = clip_screen_polygon(
             std::move(raster_polygon), target, pose.use_rotation_matrix);
         if (raster_polygon.size() < 3U) continue;
+        const StoredRasterScope raster{target, settings_.render_scale};
+        for (auto& vertex : raster_polygon) {
+            scale_to_stored(vertex.point, settings_.render_scale);
+        }
         if (material.texture == nullptr) {
             fill_source_polygon(target, raster_polygon, material.colour,
                 settings_.colour_index_base, pose, surfaces, surface);

--- a/src/simulation/game_simulation.cpp
+++ b/src/simulation/game_simulation.cpp
@@ -20,6 +20,18 @@ constexpr std::array<DisplayMode, 5> kDisplayModes{
     DisplayMode::ultrawide_21_9,
     DisplayMode::super_ultrawide_32_9,
 };
+constexpr std::array<RenderScale, render_scale_count> kRenderScales{
+    RenderScale::scale_1x,
+    RenderScale::scale_2x,
+    RenderScale::scale_3x,
+    RenderScale::scale_4x,
+    RenderScale::scale_5x,
+    RenderScale::scale_6x,
+    RenderScale::scale_7x,
+    RenderScale::scale_8x,
+    RenderScale::scale_9x,
+    RenderScale::scale_10x,
+};
 constexpr std::array<CrosshairColour, 8> kCrosshairColours{
     CrosshairColour::green,
     CrosshairColour::white,
@@ -958,6 +970,7 @@ void GameSimulation::enter_pregame_menu() {
     msu1_music_ = false;
     rumble_ = true;
     crosshair_colour_ = CrosshairColour::green;
+    render_scale_ = RenderScale::scale_1x;
     armed_god_nukes_.clear();
     flow_ticks_ = 0U;
     frontend_frames_ = 0U;
@@ -988,7 +1001,7 @@ GameTickResult GameSimulation::tick_pregame_menu(
 
     const auto previous_selection = pregame_selection_;
     const auto selection_count = pregame_page_ == PregamePage::main
-        ? std::uint8_t{14U} : std::uint8_t{5U};
+        ? std::uint8_t{14U} : std::uint8_t{6U};
     if ((input.pressed & starfox::input::up) != 0U) {
         pregame_selection_ = static_cast<std::uint8_t>(
             (pregame_selection_ + selection_count - 1U) % selection_count);
@@ -1000,7 +1013,7 @@ GameTickResult GameSimulation::tick_pregame_menu(
 
     if (pregame_page_ == PregamePage::options) {
         const auto go_back = (input.pressed & starfox::input::b) != 0U
-            || (pregame_selection_ == 4U
+            || (pregame_selection_ == 5U
                 && (input.pressed & (starfox::input::a
                     | starfox::input::select)) != 0U);
         if (go_back) {
@@ -1037,6 +1050,24 @@ GameTickResult GameSimulation::tick_pregame_menu(
                 index = (index + 1U) % kCrosshairColours.size();
             }
             crosshair_colour_ = kCrosshairColours[index];
+            queue_sound_effect(0x11U);
+        } else if (pregame_selection_ == 3U
+                   && (input.pressed & (starfox::input::left
+                       | starfox::input::right | starfox::input::select
+                       | starfox::input::a)) != 0U) {
+            const auto found = std::find(
+                kRenderScales.begin(), kRenderScales.end(), render_scale_);
+            auto index = found == kRenderScales.end()
+                ? std::size_t{}
+                : static_cast<std::size_t>(
+                    std::distance(kRenderScales.begin(), found));
+            if ((input.pressed & starfox::input::left) != 0U) {
+                index = (index + kRenderScales.size() - 1U)
+                    % kRenderScales.size();
+            } else {
+                index = (index + 1U) % kRenderScales.size();
+            }
+            render_scale_ = kRenderScales[index];
             queue_sound_effect(0x11U);
         }
         result.audio_port_writes = map_.take_apu_port_writes();

--- a/tests/simulation_tests.cpp
+++ b/tests/simulation_tests.cpp
@@ -5541,10 +5541,43 @@ int main(int argc, char** argv) {
                 "crosshair colour selector did not wrap backward");
         drive_boot({0, starfox::input::right, 0});
         drive_boot({0, starfox::input::down, 0});
-        require(boot_game.pregame_selection() == 3U,
-                "pre-game cursor did not reach CUSTOMIZE SCREEN");
+        require(boot_game.pregame_selection() == 3U
+                    && boot_game.render_scale()
+                        == starfox::simulation::RenderScale::scale_1x,
+                "pre-game cursor did not reach the native render scale");
+        drive_boot({0, starfox::input::right, 0});
+        require(boot_game.render_scale()
+                    == starfox::simulation::RenderScale::scale_2x,
+                "render scale selector did not advance to 2x");
+        drive_boot({0, starfox::input::right, 0});
+        require(boot_game.render_scale()
+                    == starfox::simulation::RenderScale::scale_3x,
+                "render scale selector did not advance to 3x");
+        drive_boot({0, starfox::input::left, 0});
+        require(boot_game.render_scale()
+                    == starfox::simulation::RenderScale::scale_2x,
+                "render scale selector did not step back to 2x");
+        drive_boot({0, starfox::input::left, 0});
+        drive_boot({0, starfox::input::left, 0});
+        require(boot_game.render_scale()
+                    == starfox::simulation::RenderScale::scale_10x,
+                "render scale selector did not wrap backward to 10x");
+        for (std::size_t step = 0;
+             step < starfox::simulation::render_scale_count; ++step) {
+            drive_boot({0, starfox::input::right, 0});
+        }
+        require(boot_game.render_scale()
+                    == starfox::simulation::RenderScale::scale_10x,
+                "render scale selector did not cycle through every scale");
+        drive_boot({0, starfox::input::right, 0});
+        require(boot_game.render_scale()
+                    == starfox::simulation::RenderScale::scale_1x,
+                "render scale selector did not wrap forward to native");
         drive_boot({0, starfox::input::down, 0});
         require(boot_game.pregame_selection() == 4U,
+                "pre-game cursor did not reach CUSTOMIZE SCREEN");
+        drive_boot({0, starfox::input::down, 0});
+        require(boot_game.pregame_selection() == 5U,
                 "pre-game cursor did not reach OPTIONS BACK");
         drive_boot({0, starfox::input::a, 0});
         require(boot_game.pregame_page()
@@ -5558,7 +5591,9 @@ int main(int argc, char** argv) {
                      && boot_game.rtx_lighting()
                     && boot_game.vsync()
                     && boot_game.crosshair_colour()
-                        == starfox::simulation::CrosshairColour::green,
+                        == starfox::simulation::CrosshairColour::green
+                    && boot_game.render_scale()
+                        == starfox::simulation::RenderScale::scale_1x,
                 "OPTIONS did not retain its toggles when returning to setup");
         drive_boot({0, starfox::input::down, 0});
         require(boot_game.pregame_selection() == 13U,


### PR DESCRIPTION
This adds RENDER SCALE to the OPTIONS page. It draws the 3D world at up to ten times its normal size, so the edges of ships, buildings and the laser lines come out much cleaner. The HUD, sprites, backgrounds and text are left alone and keep the look they were drawn with.

The setting only changes the very last step, where shapes get filled in as pixels. Everything that decides what you actually see still runs at the original size: where each corner lands on screen, which faces point towards you, what gets cut off at the edges, and the order things are drawn. The finished shape is scaled up only at the moment it's filled in.

I did try changing the earlier maths first, and it was wrong. Shapes that pass through the camera get thrown far off screen and rely on a limit built into the original code. Scaling that maths skipped the limit and made lasers and the intro ship stretch across the screen. Your own comment about the intro lasers showing "a broad side face as a full-screen wedge" describes the same fault, so I left the original math alone.