### PR TITLE
Include the UltraStarFox source so it comes with the project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 /build/
 /out/
-/upstream-ultrastarfox/
 /upstream-star-fox-ex/
 /upstream-retro-cpu/
 /upstream-snes-spc/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,5 @@
+[submodule "upstream-ultrastarfox"]
+	path = upstream-ultrastarfox
+	url = https://github.com/Sunlitspace542/ultrastarfox.git
+	# The DOS assembler writes its outputs into the checkout.
+	ignore = untracked

--- a/README.md
+++ b/README.md
@@ -129,11 +129,13 @@ for source-to-port comparisons.
 
 ## UltraStarFox source setup
 
-The required Original revision is pinned in `config/upstream.json`:
+The required Original revision is pinned in `config/upstream.json` and tracked
+as a submodule, so `git clone --recurse-submodules` fetches the source with the
+repository and the pin keeps the embedded symbol tables bound to the checked-in
+BPS deltas:
 
 ```powershell
-git clone https://github.com/Sunlitspace542/ultrastarfox.git upstream-ultrastarfox
-git -C upstream-ultrastarfox checkout 270e959a47d82240d9290a6c6630032c9ec53ff5
+git submodule update --init upstream-ultrastarfox
 powershell -ExecutionPolicy Bypass -File tools/build_upstream.ps1
 ```
 


### PR DESCRIPTION
This is a suggestion rather than a fix, so please treat it as one.

Right now the UltraStarFox source has to be fetched by hand, and nothing checks it stays on the right version. This links it to the project instead, fixed to the version already named in config/upstream.json.

It's a small change but it changes how someone sets the project up, which is your call.