### PR TITLE
Make the game build and run on Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,10 @@
 /upstream-retro-cpu/
 /upstream-snes-spc/
 Starfox-Assets.BIN
+# User-supplied retail cartridge dumps are never redistributed.
+*.sfc
+*.smc
+/dist/StarFoxEnhanced/starfox_pc
 /dist/StarFoxEnhanced/starfox_pc.exe
 /assets/hud_editor/*.bmp
 /tmp/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ project(starfox_enhanced VERSION 0.1.0 LANGUAGES CXX)
 option(STARFOX_BUILD_TESTS "Build deterministic timing tests" ON)
 option(STARFOX_BUILD_RUNTIME "Build the SDL3 native PC runtime" ON)
 option(STARFOX_EMBED_RUNTIME_ASSETS
-    "Embed source-built BPS deltas and symbol tables into the Windows runtime" ON)
+    "Embed source-built BPS deltas and symbol tables into the native runtime" ON)
 option(STARFOX_PACKAGE_MSU1_MUSIC
     "Build and install the optional Starfox-MSU1.PAK companion" ON)
 set(STARFOX_ROM_FILE
@@ -26,23 +26,30 @@ set(STARFOX_ORIGINAL_PATCH_FILE
 set(STARFOX_EX_PATCH_FILE
     "${CMAKE_CURRENT_SOURCE_DIR}/assets/patches/starfox-ex-v12.bps"
     CACHE FILEPATH "Star Fox EX BPS delta for a clean Star Fox USA v1.2 ROM")
+if(WIN32)
+    set(STARFOX_RETAIL_ROM_DIR "C:/NTSC-US Super Nintendo System Roms"
+        CACHE PATH "Directory searched for the clean retail validation ROMs")
+else()
+    set(STARFOX_RETAIL_ROM_DIR "$ENV{HOME}/NTSC-US Super Nintendo System Roms"
+        CACHE PATH "Directory searched for the clean retail validation ROMs")
+endif()
 set(STARFOX_RETAIL_V12_FILE
-    "C:/NTSC-US Super Nintendo System Roms/Star Fox (USA) (Rev 2).sfc"
+    "${STARFOX_RETAIL_ROM_DIR}/Star Fox (USA) (Rev 2).sfc"
     CACHE FILEPATH "Clean Star Fox USA v1.2 ROM used only for local validation")
 set(STARFOX_RETAIL_JAPAN_V10_FILE
-    "C:/NTSC-US Super Nintendo System Roms/Star Fox (Japan).sfc")
+    "${STARFOX_RETAIL_ROM_DIR}/Star Fox (Japan).sfc")
 set(STARFOX_RETAIL_JAPAN_V11_FILE
-    "C:/NTSC-US Super Nintendo System Roms/Star Fox (Japan) (Rev 1).sfc")
+    "${STARFOX_RETAIL_ROM_DIR}/Star Fox (Japan) (Rev 1).sfc")
 set(STARFOX_RETAIL_USA_V10_FILE
-    "C:/NTSC-US Super Nintendo System Roms/Star Fox (USA).sfc")
+    "${STARFOX_RETAIL_ROM_DIR}/Star Fox (USA).sfc")
 set(STARFOX_RETAIL_USA_V11_FILE
-    "C:/NTSC-US Super Nintendo System Roms/Star Fox (USA) (Rev 1).sfc")
+    "${STARFOX_RETAIL_ROM_DIR}/Star Fox (USA) (Rev 1).sfc")
 set(STARFOX_RETAIL_EUROPE_V10_FILE
-    "C:/NTSC-US Super Nintendo System Roms/Starwing (Europe).sfc")
+    "${STARFOX_RETAIL_ROM_DIR}/Starwing (Europe).sfc")
 set(STARFOX_RETAIL_EUROPE_V11_FILE
-    "C:/NTSC-US Super Nintendo System Roms/Starwing (Europe) (Rev 1).sfc")
+    "${STARFOX_RETAIL_ROM_DIR}/Starwing (Europe) (Rev 1).sfc")
 set(STARFOX_RETAIL_GERMANY_V10_FILE
-    "C:/NTSC-US Super Nintendo System Roms/Starwing (Germany).sfc")
+    "${STARFOX_RETAIL_ROM_DIR}/Starwing (Germany).sfc")
 set(STARFOX_RETAIL_JAPAN_V10_PATCH_FILE
     "${CMAKE_CURRENT_SOURCE_DIR}/assets/patches/retail-japan-v10-to-usa-v12.bps")
 set(STARFOX_RETAIL_JAPAN_V11_PATCH_FILE
@@ -201,7 +208,6 @@ if(STARFOX_BUILD_RUNTIME)
         set_target_properties(starfox_pc PROPERTIES WIN32_EXECUTABLE TRUE)
     endif()
     target_link_libraries(starfox_pc PRIVATE starfox_core SDL3::SDL3)
-
     if(STARFOX_PACKAGE_MSU1_MUSIC)
         FetchContent_Declare(
             starfox_msu_pack
@@ -251,7 +257,7 @@ if(STARFOX_BUILD_RUNTIME)
         install(FILES "${STARFOX_MSU1_PACK}" DESTINATION .)
     endif()
 
-    if(WIN32 AND STARFOX_EMBED_RUNTIME_ASSETS)
+    if(STARFOX_EMBED_RUNTIME_ASSETS)
         if(EXISTS "${STARFOX_ORIGINAL_PATCH_FILE}"
            AND EXISTS "${STARFOX_SYMBOLS_FILE}"
            AND EXISTS "${STARFOX_EX_PATCH_FILE}"
@@ -263,7 +269,9 @@ if(STARFOX_BUILD_RUNTIME)
            AND EXISTS "${STARFOX_RETAIL_EUROPE_V10_PATCH_FILE}"
            AND EXISTS "${STARFOX_RETAIL_EUROPE_V11_PATCH_FILE}"
            AND EXISTS "${STARFOX_RETAIL_GERMANY_V10_PATCH_FILE}")
-            enable_language(RC)
+            if(WIN32)
+                enable_language(RC)
+            endif()
             file(TO_CMAKE_PATH
                 "${STARFOX_ORIGINAL_PATCH_FILE}" STARFOX_EMBEDDED_PATCH)
             file(TO_CMAKE_PATH "${STARFOX_SYMBOLS_FILE}" STARFOX_EMBEDDED_SYMBOLS)
@@ -284,19 +292,39 @@ if(STARFOX_BUILD_RUNTIME)
                 STARFOX_RETAIL_EUROPE_V11_PATCH)
             file(TO_CMAKE_PATH "${STARFOX_RETAIL_GERMANY_V10_PATCH_FILE}"
                 STARFOX_RETAIL_GERMANY_V10_PATCH)
-            configure_file(
-                src/app/starfox_assets.rc.in
-                "${CMAKE_CURRENT_BINARY_DIR}/starfox_assets.rc"
-                @ONLY
-            )
+            if(WIN32)
+                configure_file(
+                    src/app/starfox_assets.rc.in
+                    "${CMAKE_CURRENT_BINARY_DIR}/starfox_assets.rc"
+                    @ONLY
+                )
+                set(STARFOX_EMBEDDED_SOURCE
+                    "${CMAKE_CURRENT_BINARY_DIR}/starfox_assets.rc")
+            else()
+                enable_language(ASM)
+                configure_file(
+                    src/app/starfox_assets.s.in
+                    "${CMAKE_CURRENT_BINARY_DIR}/starfox_assets.s"
+                    @ONLY
+                )
+                set(STARFOX_EMBEDDED_SOURCE
+                    "${CMAKE_CURRENT_BINARY_DIR}/starfox_assets.s")
+            endif()
+            # Neither the resource compiler nor .incbin reports the payloads
+            # it reads, so a reassembled ROM would otherwise keep a stale
+            # runtime.
+            set_source_files_properties("${STARFOX_EMBEDDED_SOURCE}" PROPERTIES
+                OBJECT_DEPENDS "${STARFOX_EMBEDDED_PATCH};\
+${STARFOX_EMBEDDED_SYMBOLS};${STARFOX_EX_EMBEDDED_PATCH};\
+${STARFOX_EX_EMBEDDED_SYMBOLS};${STARFOX_RETAIL_JAPAN_V10_PATCH};\
+${STARFOX_RETAIL_JAPAN_V11_PATCH};${STARFOX_RETAIL_USA_V10_PATCH};\
+${STARFOX_RETAIL_USA_V11_PATCH};${STARFOX_RETAIL_EUROPE_V10_PATCH};\
+${STARFOX_RETAIL_EUROPE_V11_PATCH};${STARFOX_RETAIL_GERMANY_V10_PATCH}")
             # Keep the resource compiler isolated from the C++ target's
             # include path. GNU windres forwards quoted -I paths through its
             # preprocessor incorrectly when the workspace contains spaces.
             add_library(starfox_runtime_resources OBJECT
-                "${CMAKE_CURRENT_BINARY_DIR}/starfox_assets.rc")
-            set_property(SOURCE "${CMAKE_CURRENT_BINARY_DIR}/starfox_assets.rc"
-                PROPERTY OBJECT_DEPENDS
-                    "${STARFOX_ORIGINAL_PATCH_FILE};${STARFOX_SYMBOLS_FILE};${STARFOX_EX_PATCH_FILE};${STARFOX_EX_SYMBOLS_FILE};${STARFOX_RETAIL_JAPAN_V10_PATCH_FILE};${STARFOX_RETAIL_JAPAN_V11_PATCH_FILE};${STARFOX_RETAIL_USA_V10_PATCH_FILE};${STARFOX_RETAIL_USA_V11_PATCH_FILE};${STARFOX_RETAIL_EUROPE_V10_PATCH_FILE};${STARFOX_RETAIL_EUROPE_V11_PATCH_FILE};${STARFOX_RETAIL_GERMANY_V10_PATCH_FILE}")
+                "${STARFOX_EMBEDDED_SOURCE}")
             target_sources(starfox_pc PRIVATE
                 $<TARGET_OBJECTS:starfox_runtime_resources>)
             target_compile_definitions(starfox_pc PRIVATE

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Star Fox Enhanced
 
-A native Windows PC port of the open-source
+A native Windows and Linux PC port of the open-source
 [UltraStarFox](https://github.com/Sunlitspace542/ultrastarfox) codebase. It
 presents at a selectable 20, 30, 60, 90, 120, 240, 360, or 480 frames per
 second while preserving the original game's intended NTSC simulation speed
@@ -8,7 +8,7 @@ and assembled model data. The default is 60 FPS.
 
 This repository is an early playable fidelity pass. It does not track a game
 executable, retail ROM, reconstructed ROM, or generated asset companion. The
-Windows executable embeds source-built BPS deltas and symbol data. The
+native executable embeds source-built BPS deltas and symbol data. The
 complete optional compressed MSU-1 music set is distributed separately as
 `Starfox-MSU1.PAK` beside the executable. On its
 first launch it validates the user's own unmodified Star Fox USA v1.2 (Rev 2)
@@ -79,7 +79,7 @@ in a resizable window. It is a hybrid source port: a pinned 65C816 core
 executes bounded original routines while timing, asset decoding, simulation
 orchestration, rendering, audio output, and presentation are native C++.
 
-## Quick start (Windows)
+## Quick start
 
 Build the pinned UltraStarFox and Star Fox EX sources first so their local ROM
 and symbol outputs exist. These generated files stay ignored and untracked:
@@ -97,6 +97,10 @@ Then run:
 .\play-starfox.ps1
 ```
 
+```bash
+./play-starfox.sh
+```
+
 The launcher configures an optimized build on first use and starts at the
 pre-game setup. On the executable's first run, supply any supported unmodified
 1 MiB retail Star Fox/Starwing ROM:
@@ -106,7 +110,8 @@ Star Fox (Japan), revisions 1.0 or 1.1
 Star Fox (USA), revisions 1.0, 1.1, or 1.2
 Starwing (Europe), revisions 1.0 or 1.1
 Starwing (Germany), revision 1.0
-the ROM beside starfox_pc.exe or in C:\NTSC-US Super Nintendo System Roms
+the ROM beside the executable, in C:\NTSC-US Super Nintendo System Roms on
+Windows, or in ~/NTSC-US Super Nintendo System Roms on Linux
 the path named by STARFOX_RETAIL_ROM
 ```
 
@@ -122,6 +127,10 @@ A development map can be selected explicitly:
 
 ```powershell
 .\play-starfox.ps1 LEVEL1_1
+```
+
+```bash
+./play-starfox.sh LEVEL1_1
 ```
 
 Explicit external ROM/symbol pairs can still be passed to a development build
@@ -141,7 +150,8 @@ The UltraStarFox DOSBox assembler toolchain must be present in that checkout,
 as described by its own build instructions. The helper idempotently applies
 `config/ultrastarfox-native-runtime.patch`, which enables the authored MSU-1
 and rumble events while retaining stock SPC music for the runtime ON/OFF
-switch and routing the physical rumble transmitter through SDL.
+switch and routing the physical rumble transmitter through SDL. On Linux, run
+`tools/build_upstream.sh` in place of the PowerShell helper.
 
 The Star Fox EX 1.11.03 source revision is pinned separately in
 `config/upstream-ex.json`:
@@ -152,13 +162,26 @@ git -C upstream-star-fox-ex checkout b5e2d837a15a72a532cd019bfe332b7a4b660924
 powershell -ExecutionPolicy Bypass -File tools/build_starfox_ex.ps1
 ```
 
-That checkout also supplies its DOSBox assembler toolchain. Both build helpers
-reject a different source revision so the embedded symbol tables remain bound
-to the checked-in BPS deltas.
+That checkout also supplies its DOSBox assembler toolchain. On Linux, run
+`tools/build_starfox_ex.sh` in place of the PowerShell helper; both shell
+helpers drive a native `dosbox-x` from `PATH`. Both build helpers reject a
+different source revision so the embedded symbol tables remain bound to the
+checked-in BPS deltas.
 
 ## Build and test
 
-```powershell
+SDL3 is built from source, so a Linux host needs its development packages
+first. On Fedora:
+
+```bash
+sudo dnf install libX11-devel libXext-devel libXcursor-devel \
+    libXrandr-devel libXfixes-devel libXi-devel libXtst-devel \
+    libXScrnSaver-devel libxkbcommon-devel wayland-devel libdecor-devel \
+    mesa-libGL-devel mesa-libEGL-devel dbus-devel alsa-lib-devel \
+    pulseaudio-libs-devel pipewire-devel ibus-devel
+```
+
+```text
 cmake -S . -B build/release -G Ninja -DCMAKE_BUILD_TYPE=Release
 cmake --build build/release -j 8
 ctest --test-dir build/release --output-on-failure
@@ -166,21 +189,22 @@ ctest --test-dir build/release --output-on-failure
 
 Create a portable executable folder (ROM data remains user-supplied):
 
-```powershell
+```text
 cmake --install build/release --prefix dist/StarFoxEnhanced
 ```
 
 The default build downloads the pinned music sources and installs the optional
-`Starfox-MSU1.PAK` beside `starfox_pc.exe`. Configure with
+`Starfox-MSU1.PAK` beside the executable. Configure with
 `-DSTARFOX_PACKAGE_MSU1_MUSIC=OFF` to build and install the game without that
 companion; the executable remains fully playable with the original SPC music.
 
-You can launch the binary directly:
+You can launch the binary directly, as `starfox_pc.exe` on Windows and
+`starfox_pc` on Linux:
 
-```powershell
-build/release/starfox_pc.exe
-build/release/starfox_pc.exe LEVEL2_3
-build/release/starfox_pc.exe path/to/SF.SFC path/to/SYMBOLS.TXT TITLEMAP
+```text
+build/release/starfox_pc
+build/release/starfox_pc LEVEL2_3
+build/release/starfox_pc path/to/SF.SFC path/to/SYMBOLS.TXT TITLEMAP
 ```
 
 ## Controls

--- a/include/starfox/app/runtime_input.hpp
+++ b/include/starfox/app/runtime_input.hpp
@@ -97,6 +97,9 @@ struct PregameSettings {
     [[nodiscard]] bool operator==(const PregameSettings&) const = default;
 };
 
+// Guards the preference directory against a second concurrent runtime.
+[[nodiscard]] std::filesystem::path single_instance_lock_path();
+
 // Front-end choices live beside HUD layouts in Documents so presentation and
 // accessibility settings survive upgrades and self-contained EXE moves.
 [[nodiscard]] std::filesystem::path pregame_settings_path();

--- a/play-starfox.sh
+++ b/play-starfox.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+map="${1:-BOOT}"
+project_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+rom_path="$project_root/upstream-ultrastarfox/SF.SFC"
+symbols_path="$project_root/upstream-ultrastarfox/SYMBOLS.TXT"
+ex_rom_path="$project_root/upstream-star-fox-ex/SFES/SFES.SFC"
+ex_symbols_path="$project_root/upstream-star-fox-ex/SYMBOLS.TXT"
+build_path="$project_root/build/release"
+executable_path="$build_path/starfox_pc"
+
+for required in "$rom_path" "$symbols_path" "$ex_rom_path" "$ex_symbols_path"; do
+    if [[ ! -f $required ]]; then
+        echo "Missing Original or EX build output. Run tools/build_upstream.sh and tools/build_starfox_ex.sh first." >&2
+        exit 1
+    fi
+done
+
+if [[ ! -x $executable_path ]]; then
+    cmake -S "$project_root" -B "$build_path" -G Ninja -DCMAKE_BUILD_TYPE=Release
+    cmake --build "$build_path" --target starfox_pc -j 8
+fi
+
+exec "$executable_path" "$rom_path" "$symbols_path" "$map"

--- a/src/app/runtime_input.cpp
+++ b/src/app/runtime_input.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cstdlib>
 #include <filesystem>
 #include <fstream>
 #include <sstream>
@@ -97,13 +98,18 @@ int gamepad_preference(SDL_JoystickID identifier) {
     return score;
 }
 
-std::filesystem::path settings_path() {
+std::filesystem::path preference_directory() {
     char* preference_path = SDL_GetPrefPath("StarFoxEnhanced", "StarFoxEnhanced");
     if (preference_path == nullptr) return {};
-    const std::filesystem::path result =
-        std::filesystem::path{preference_path} / "input-bindings.cfg";
+    const std::filesystem::path result{preference_path};
     SDL_free(preference_path);
     return result;
+}
+
+std::filesystem::path settings_path() {
+    const auto directory = preference_directory();
+    if (directory.empty()) return {};
+    return directory / "input-bindings.cfg";
 }
 
 std::filesystem::path documents_settings_path(std::string_view filename) {
@@ -116,6 +122,12 @@ std::filesystem::path documents_settings_path(std::string_view filename) {
     if (const auto* profile = std::getenv("USERPROFILE");
         profile != nullptr && *profile != '\0') {
         return std::filesystem::path{profile}
+            / "Documents" / "Star Fox Enhanced" / filename;
+    }
+#else
+    if (const auto* home = std::getenv("HOME");
+        home != nullptr && *home != '\0') {
+        return std::filesystem::path{home}
             / "Documents" / "Star Fox Enhanced" / filename;
     }
 #endif
@@ -435,6 +447,12 @@ void InputBindings::save() const {
         output << "G " << action << ' ' << kind << ' '
                << binding.control << '\n';
     }
+}
+
+std::filesystem::path single_instance_lock_path() {
+    const auto directory = preference_directory();
+    if (directory.empty()) return {};
+    return directory / "runtime.lock";
 }
 
 std::filesystem::path pregame_settings_path() {

--- a/src/app/starfox_assets.s.in
+++ b/src/app/starfox_assets.s.in
@@ -1,0 +1,70 @@
+    .section .rodata
+    .balign 4
+
+    .globl starfox_patch_begin
+    .globl starfox_patch_end
+starfox_patch_begin:
+    .incbin "@STARFOX_EMBEDDED_PATCH@"
+starfox_patch_end:
+
+    .globl starfox_symbols_begin
+    .globl starfox_symbols_end
+starfox_symbols_begin:
+    .incbin "@STARFOX_EMBEDDED_SYMBOLS@"
+starfox_symbols_end:
+
+    .globl starfox_ex_patch_begin
+    .globl starfox_ex_patch_end
+starfox_ex_patch_begin:
+    .incbin "@STARFOX_EX_EMBEDDED_PATCH@"
+starfox_ex_patch_end:
+
+    .globl starfox_ex_symbols_begin
+    .globl starfox_ex_symbols_end
+starfox_ex_symbols_begin:
+    .incbin "@STARFOX_EX_EMBEDDED_SYMBOLS@"
+starfox_ex_symbols_end:
+
+    .globl starfox_retail_japan_v10_patch_begin
+    .globl starfox_retail_japan_v10_patch_end
+starfox_retail_japan_v10_patch_begin:
+    .incbin "@STARFOX_RETAIL_JAPAN_V10_PATCH@"
+starfox_retail_japan_v10_patch_end:
+
+    .globl starfox_retail_japan_v11_patch_begin
+    .globl starfox_retail_japan_v11_patch_end
+starfox_retail_japan_v11_patch_begin:
+    .incbin "@STARFOX_RETAIL_JAPAN_V11_PATCH@"
+starfox_retail_japan_v11_patch_end:
+
+    .globl starfox_retail_usa_v10_patch_begin
+    .globl starfox_retail_usa_v10_patch_end
+starfox_retail_usa_v10_patch_begin:
+    .incbin "@STARFOX_RETAIL_USA_V10_PATCH@"
+starfox_retail_usa_v10_patch_end:
+
+    .globl starfox_retail_usa_v11_patch_begin
+    .globl starfox_retail_usa_v11_patch_end
+starfox_retail_usa_v11_patch_begin:
+    .incbin "@STARFOX_RETAIL_USA_V11_PATCH@"
+starfox_retail_usa_v11_patch_end:
+
+    .globl starfox_retail_europe_v10_patch_begin
+    .globl starfox_retail_europe_v10_patch_end
+starfox_retail_europe_v10_patch_begin:
+    .incbin "@STARFOX_RETAIL_EUROPE_V10_PATCH@"
+starfox_retail_europe_v10_patch_end:
+
+    .globl starfox_retail_europe_v11_patch_begin
+    .globl starfox_retail_europe_v11_patch_end
+starfox_retail_europe_v11_patch_begin:
+    .incbin "@STARFOX_RETAIL_EUROPE_V11_PATCH@"
+starfox_retail_europe_v11_patch_end:
+
+    .globl starfox_retail_germany_v10_patch_begin
+    .globl starfox_retail_germany_v10_patch_end
+starfox_retail_germany_v10_patch_begin:
+    .incbin "@STARFOX_RETAIL_GERMANY_V10_PATCH@"
+starfox_retail_germany_v10_patch_end:
+
+    .section .note.GNU-stack,"",%progbits

--- a/src/app/starfox_pc.cpp
+++ b/src/app/starfox_pc.cpp
@@ -41,6 +41,7 @@
 #include <stdexcept>
 #include <string>
 #include <string_view>
+#include <system_error>
 #include <thread>
 #include <unordered_map>
 #include <unordered_set>
@@ -50,6 +51,10 @@
 #if defined(_WIN32)
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
+#else
+#include <fcntl.h>
+#include <sys/file.h>
+#include <unistd.h>
 #endif
 
 namespace {
@@ -388,7 +393,8 @@ std::vector<ScriptedPress> parse_scripted_presses(const char* text) {
     return result;
 }
 
-#if defined(_WIN32) && defined(STARFOX_HAS_EMBEDDED_ASSETS)
+#if defined(STARFOX_HAS_EMBEDDED_ASSETS)
+#if defined(_WIN32)
 std::span<const std::uint8_t> embedded_resource(int identifier) {
     const auto module = GetModuleHandleW(nullptr);
     const auto resource = FindResourceW(
@@ -408,6 +414,75 @@ std::span<const std::uint8_t> embedded_resource(int identifier) {
     return std::span<const std::uint8_t>{
         data, static_cast<std::size_t>(size)};
 }
+#else
+// starfox_assets.s.in binds each payload into .rodata under these symbols.
+extern "C" {
+extern const std::uint8_t starfox_patch_begin[];
+extern const std::uint8_t starfox_patch_end[];
+extern const std::uint8_t starfox_symbols_begin[];
+extern const std::uint8_t starfox_symbols_end[];
+extern const std::uint8_t starfox_ex_patch_begin[];
+extern const std::uint8_t starfox_ex_patch_end[];
+extern const std::uint8_t starfox_ex_symbols_begin[];
+extern const std::uint8_t starfox_ex_symbols_end[];
+extern const std::uint8_t starfox_retail_japan_v10_patch_begin[];
+extern const std::uint8_t starfox_retail_japan_v10_patch_end[];
+extern const std::uint8_t starfox_retail_japan_v11_patch_begin[];
+extern const std::uint8_t starfox_retail_japan_v11_patch_end[];
+extern const std::uint8_t starfox_retail_usa_v10_patch_begin[];
+extern const std::uint8_t starfox_retail_usa_v10_patch_end[];
+extern const std::uint8_t starfox_retail_usa_v11_patch_begin[];
+extern const std::uint8_t starfox_retail_usa_v11_patch_end[];
+extern const std::uint8_t starfox_retail_europe_v10_patch_begin[];
+extern const std::uint8_t starfox_retail_europe_v10_patch_end[];
+extern const std::uint8_t starfox_retail_europe_v11_patch_begin[];
+extern const std::uint8_t starfox_retail_europe_v11_patch_end[];
+extern const std::uint8_t starfox_retail_germany_v10_patch_begin[];
+extern const std::uint8_t starfox_retail_germany_v10_patch_end[];
+}
+
+struct EmbeddedAsset {
+    int identifier;
+    const std::uint8_t* begin;
+    const std::uint8_t* end;
+};
+
+constexpr std::array embedded_assets{
+    EmbeddedAsset{101, starfox_patch_begin, starfox_patch_end},
+    EmbeddedAsset{102, starfox_symbols_begin, starfox_symbols_end},
+    EmbeddedAsset{108, starfox_ex_patch_begin, starfox_ex_patch_end},
+    EmbeddedAsset{109, starfox_ex_symbols_begin, starfox_ex_symbols_end},
+    EmbeddedAsset{120, starfox_retail_japan_v10_patch_begin,
+        starfox_retail_japan_v10_patch_end},
+    EmbeddedAsset{121, starfox_retail_japan_v11_patch_begin,
+        starfox_retail_japan_v11_patch_end},
+    EmbeddedAsset{122, starfox_retail_usa_v10_patch_begin,
+        starfox_retail_usa_v10_patch_end},
+    EmbeddedAsset{123, starfox_retail_usa_v11_patch_begin,
+        starfox_retail_usa_v11_patch_end},
+    EmbeddedAsset{124, starfox_retail_europe_v10_patch_begin,
+        starfox_retail_europe_v10_patch_end},
+    EmbeddedAsset{125, starfox_retail_europe_v11_patch_begin,
+        starfox_retail_europe_v11_patch_end},
+    EmbeddedAsset{126, starfox_retail_germany_v10_patch_begin,
+        starfox_retail_germany_v10_patch_end},
+};
+
+std::span<const std::uint8_t> embedded_resource(int identifier) {
+    const auto asset = std::find_if(embedded_assets.begin(),
+        embedded_assets.end(), [identifier](const EmbeddedAsset& candidate) {
+            return candidate.identifier == identifier;
+        });
+    if (asset == embedded_assets.end()) {
+        throw std::runtime_error{"embedded Star Fox asset resource is missing"};
+    }
+    if (asset->end <= asset->begin) {
+        throw std::runtime_error{"embedded Star Fox asset resource is invalid"};
+    }
+    return std::span<const std::uint8_t>{asset->begin,
+        static_cast<std::size_t>(asset->end - asset->begin)};
+}
+#endif
 
 RuntimeAssets make_runtime_assets(
     std::vector<std::uint8_t> rom,
@@ -484,6 +559,16 @@ std::vector<std::uint8_t> canonicalize_retail_rom(
     return canonical;
 }
 
+std::filesystem::path retail_library_directory() {
+#if defined(_WIN32)
+    return std::filesystem::path{R"(C:\NTSC-US Super Nintendo System Roms)"};
+#else
+    const auto* home = std::getenv("HOME");
+    if (home == nullptr || *home == '\0') return {};
+    return std::filesystem::path{home} / "NTSC-US Super Nintendo System Roms";
+#endif
+}
+
 std::pair<std::filesystem::path, std::vector<std::uint8_t>>
 load_required_retail(const std::filesystem::path& executable_directory) {
     std::vector<std::filesystem::path> candidates;
@@ -506,11 +591,11 @@ load_required_retail(const std::filesystem::path& executable_directory) {
         "Star Fox v1.2.sfc",
     };
     const std::array directories{
-        std::filesystem::path{
-            R"(C:\NTSC-US Super Nintendo System Roms)"},
+        retail_library_directory(),
         executable_directory,
     };
     for (const auto& directory : directories) {
+        if (directory.empty()) continue;
         for (const auto* filename : filenames) {
             candidates.emplace_back(directory / filename);
         }
@@ -528,8 +613,9 @@ load_required_retail(const std::filesystem::path& executable_directory) {
     throw std::runtime_error{
         "Star Fox Enhanced requires an unmodified retail Star Fox/Starwing "
         "ROM: Japan 1.0/1.1, USA 1.0/1.1/1.2, Europe 1.0/1.1, or Germany "
-        "1.0. Place it beside the game, in C:\\NTSC-US Super Nintendo "
-        "System Roms, or set STARFOX_RETAIL_ROM to its full path."};
+        "1.0. Place it beside the game, in "
+        + retail_library_directory().string()
+        + ", or set STARFOX_RETAIL_ROM to its full path."};
 }
 
 std::uint32_t embedded_asset_manifest() {
@@ -581,6 +667,7 @@ void write_asset_companion(
                 "unable to write asset companion: " + path.string()};
         }
     }
+#if defined(_WIN32)
     if (!MoveFileExW(temporary.c_str(), path.c_str(),
             MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH)) {
         const auto error = GetLastError();
@@ -589,6 +676,17 @@ void write_asset_companion(
             "unable to install asset companion (Windows error "
             + std::to_string(error) + "): " + path.string()};
     }
+#else
+    std::error_code error;
+    std::filesystem::rename(temporary, path, error);
+    if (error) {
+        const auto reason = error.message();
+        std::filesystem::remove(temporary, error);
+        throw std::runtime_error{
+            "unable to install asset companion (" + reason + "): "
+            + path.string()};
+    }
+#endif
 }
 
 RuntimeAssetSet load_or_compile_runtime_assets(
@@ -625,6 +723,17 @@ RuntimeAssetSet load_or_compile_runtime_assets(
     return unpack_runtime_assets(std::move(payload));
 }
 #endif
+
+// argv[0] is only a resolvable path when the runtime was launched by one; the
+// companion and its side files must still land beside the real executable.
+std::filesystem::path executable_path(const char* argv0) {
+#if !defined(_WIN32)
+    std::error_code error;
+    auto resolved = std::filesystem::read_symlink("/proc/self/exe", error);
+    if (!error) return resolved;
+#endif
+    return std::filesystem::absolute(argv0);
+}
 
 RuntimeAssets load_external_assets(
     const std::filesystem::path& rom_path,
@@ -2159,10 +2268,10 @@ CameraPoint world_to_camera(
 } // namespace
 
 int main(int argc, char** argv) {
-#if defined(_WIN32)
     // Keep the lock alive through the catch block and its modal error dialog.
-    // If it lived inside try, stack unwinding released it before MessageBoxA;
+    // If it lived inside try, stack unwinding released it before the dialog;
     // a second launch could then enter and display an identical second box.
+#if defined(_WIN32)
     struct SingleInstanceMutex {
         HANDLE handle{};
         ~SingleInstanceMutex() {
@@ -2175,24 +2284,47 @@ int main(int argc, char** argv) {
         if (single_instance.handle == nullptr) return 1;
         if (GetLastError() == ERROR_ALREADY_EXISTS) return 0;
     }
+#else
+    // POSIX has no named mutex. An advisory whole-file lock is equivalent here
+    // and the kernel drops it however the process ends.
+    struct SingleInstanceLock {
+        int descriptor{-1};
+        ~SingleInstanceLock() {
+            if (descriptor >= 0) ::close(descriptor);
+        }
+    } single_instance;
+    if (std::getenv("STARFOX_TEST_FRAMES") == nullptr) {
+        const auto lock_path = starfox::app::single_instance_lock_path();
+        if (!lock_path.empty()) {
+            std::error_code lock_error;
+            std::filesystem::create_directories(
+                lock_path.parent_path(), lock_error);
+            single_instance.descriptor = ::open(
+                lock_path.c_str(), O_RDWR | O_CREAT | O_CLOEXEC, 0644);
+            if (single_instance.descriptor >= 0
+                && ::flock(single_instance.descriptor, LOCK_EX | LOCK_NB) != 0) {
+                return 0;
+            }
+        }
+    }
 #endif
     try {
         const SdlContext sdl;
         Window window;
         std::string initial_map = "BOOT";
         const auto executable_directory =
-            std::filesystem::absolute(argv[0]).parent_path();
+            executable_path(argv[0]).parent_path();
         const starfox::audio::Msu1Pack msu1_pack{
             executable_directory
                 / std::filesystem::path{starfox::audio::msu1_pack_filename}};
-#if defined(_WIN32) && defined(STARFOX_HAS_EMBEDDED_ASSETS)
+#if defined(STARFOX_HAS_EMBEDDED_ASSETS)
         auto embedded_runtime_assets =
             load_or_compile_runtime_assets(executable_directory);
 #endif
         const auto original_assets = [&]() -> RuntimeAssets {
             if (argc == 1 || argc == 2) {
                 if (argc == 2) initial_map = argv[1];
-#if defined(_WIN32) && defined(STARFOX_HAS_EMBEDDED_ASSETS)
+#if defined(STARFOX_HAS_EMBEDDED_ASSETS)
                 return std::move(embedded_runtime_assets.original);
 #else
                 std::filesystem::path rom_path;
@@ -2233,7 +2365,7 @@ int main(int argc, char** argv) {
             throw std::runtime_error{"invalid command-line arguments"};
         }();
         std::optional<RuntimeAssets> starfox_ex_assets;
-#if defined(_WIN32) && defined(STARFOX_HAS_EMBEDDED_ASSETS)
+#if defined(STARFOX_HAS_EMBEDDED_ASSETS)
         starfox_ex_assets.emplace(
             std::move(embedded_runtime_assets.starfox_ex));
 #else
@@ -5292,15 +5424,13 @@ int main(int argc, char** argv) {
         const std::string message =
             std::string{"Star Fox Enhanced could not start:\n\n"} + error.what();
         std::cerr << "starfox_pc failed: " << error.what() << '\n';
-#if defined(_WIN32)
         // Automated runtime checks must remain headless even when they find a
         // regression; stderr and the non-zero exit status are sufficient and
         // cannot strand modal dialogs on the user's desktop.
         if (std::getenv("STARFOX_TEST_FRAMES") == nullptr) {
-            MessageBoxA(nullptr, message.c_str(), "Star Fox Enhanced",
-                MB_OK | MB_ICONERROR | MB_TASKMODAL);
+            static_cast<void>(SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR,
+                "Star Fox Enhanced", message.c_str(), nullptr));
         }
-#endif
         return 1;
     }
 }

--- a/tools/build_starfox_ex.sh
+++ b/tools/build_starfox_ex.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+source_root="$(cd -- "${1:-$script_dir/../upstream-star-fox-ex}" && pwd)"
+expected_commit=b5e2d837a15a72a532cd019bfe332b7a4b660924
+
+dosbox="$source_root/dosbox-x"
+if [[ ! -x $dosbox ]]; then
+    dosbox="$(command -v dosbox-x || true)"
+fi
+if [[ -z $dosbox ]]; then
+    echo "Star Fox EX DOSBox toolchain not found in $source_root or on PATH" >&2
+    exit 1
+fi
+
+actual_commit="$(git -C "$source_root" rev-parse HEAD)"
+if [[ $actual_commit != "$expected_commit" ]]; then
+    echo "Star Fox EX must be checked out at $expected_commit (found $actual_commit)" >&2
+    exit 1
+fi
+
+batch_path="$source_root/.starfox-port-ex-build.bat"
+success_path="$source_root/.starfox-port-ex-build.ok"
+if [[ -e $batch_path ]]; then
+    echo "Refusing to overwrite existing temporary build file: $batch_path" >&2
+    exit 1
+fi
+trap 'rm -f "$batch_path" "$success_path"' EXIT
+
+rm -f "$success_path"
+printf '%s\r\n' \
+    '@echo off' \
+    'set path=%path%;c:\bin' \
+    'set sasmheap=14400' \
+    'cd sfes' \
+    'make clean' \
+    'if errorlevel 1 goto failed' \
+    'make hardware=0 newface=1' \
+    'if errorlevel 1 goto failed' \
+    'copy sfes.sfc ..\sfes.sfc' \
+    'if errorlevel 1 goto failed' \
+    'cd ..' \
+    'echo ok>.starfox-port-ex-build.ok' \
+    'exit' \
+    ':failed' \
+    'cd ..' \
+    'exit' > "$batch_path"
+
+if ! (cd "$source_root" && "$dosbox" -fastlaunch "$(basename "$batch_path")") \
+    || [[ ! -f $success_path ]]; then
+    echo "Star Fox EX assembler build failed" >&2
+    exit 1
+fi
+
+for name in SFES/SFES.SFC SYMBOLS.TXT BANKS.CSV; do
+    target="$source_root/$name"
+    if [[ ! -f $target ]]; then
+        # DOSBox emits 8.3 names in its own case; Linux is case-sensitive.
+        produced="$(find "$(dirname "$target")" -maxdepth 1 \
+            -iname "$(basename "$name")" -print -quit 2>/dev/null)"
+        if [[ -n $produced ]]; then
+            mv -- "$produced" "$target"
+        fi
+    fi
+    if [[ ! -f $target ]]; then
+        echo "Star Fox EX build did not produce $name" >&2
+        exit 1
+    fi
+    ls -l -- "$target"
+done

--- a/tools/build_upstream.sh
+++ b/tools/build_upstream.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+source_root="$(cd -- "${1:-$script_dir/../upstream-ultrastarfox}" && pwd)"
+expected_commit=270e959a47d82240d9290a6c6630032c9ec53ff5
+
+dosbox="$source_root/dosbox-x"
+if [[ ! -x $dosbox ]]; then
+    dosbox="$(command -v dosbox-x || true)"
+fi
+if [[ -z $dosbox ]]; then
+    echo "UltraStarFox DOSBox toolchain not found in $source_root or on PATH" >&2
+    exit 1
+fi
+
+actual_commit="$(git -C "$source_root" rev-parse HEAD)"
+if [[ $actual_commit != "$expected_commit" ]]; then
+    echo "UltraStarFox must be checked out at $expected_commit (found $actual_commit)" >&2
+    exit 1
+fi
+
+native_patch="$script_dir/../config/ultrastarfox-native-runtime.patch"
+if [[ ! -f $native_patch ]]; then
+    echo "UltraStarFox native-runtime feature patch not found at $native_patch" >&2
+    exit 1
+fi
+
+# The patch enables the MSU-1 driver the native runtime drives directly. It is
+# applied to the pinned checkout rather than committed, so tolerate a source
+# tree that is already patched from an earlier build.
+check_native_patch() {
+    git -C "$source_root" apply "$@" --check --ignore-space-change \
+        --ignore-whitespace "$native_patch" >/dev/null 2>&1
+}
+if check_native_patch; then
+    if ! git -C "$source_root" apply --ignore-space-change \
+        --ignore-whitespace "$native_patch"; then
+        echo "Could not apply the UltraStarFox native-runtime feature patch" >&2
+        exit 1
+    fi
+    # The patch is stored with LF endings but the DOS sources are CRLF, and
+    # the assembler rejects the lone-LF lines git apply leaves behind. Git for
+    # Windows hides this via core.autocrlf; restore the CRLF endings here so
+    # the patched checkout assembles the same way on Linux.
+    while IFS= read -r patched_file; do
+        [[ -n $patched_file ]] || continue
+        target="$source_root/$patched_file"
+        [[ -f $target ]] || continue
+        if grep -qU $'\r' "$target"; then
+            sed -i 's/\r*$/\r/' "$target"
+        fi
+    done < <(git -C "$source_root" diff --name-only)
+elif ! check_native_patch --reverse; then
+    echo "UltraStarFox source does not match the native-runtime feature patch" >&2
+    exit 1
+fi
+
+batch_path="$source_root/.starfox-port-build.bat"
+success_path="$source_root/.starfox-port-build.ok"
+if [[ -e $batch_path ]]; then
+    echo "Refusing to overwrite existing temporary build file: $batch_path" >&2
+    exit 1
+fi
+trap 'rm -f "$batch_path" "$success_path"' EXIT
+
+rm -f "$success_path"
+printf '%s\r\n' \
+    '@echo off' \
+    'set path=%path%;c:\bin' \
+    'cd sf' \
+    'make' \
+    'if errorlevel 1 goto failed' \
+    'cd ..' \
+    'echo ok>.starfox-port-build.ok' \
+    'exit' \
+    ':failed' \
+    'cd ..' \
+    'exit' > "$batch_path"
+
+if ! (cd "$source_root" && "$dosbox" -fastlaunch "$(basename "$batch_path")") \
+    || [[ ! -f $success_path ]]; then
+    echo "UltraStarFox assembler build failed" >&2
+    exit 1
+fi
+
+for name in SF.SFC SYMBOLS.TXT BANKS.CSV; do
+    target="$source_root/$name"
+    if [[ ! -f $target ]]; then
+        # DOSBox emits 8.3 names in its own case; Linux is case-sensitive.
+        produced="$(find "$(dirname "$target")" -maxdepth 1 \
+            -iname "$(basename "$name")" -print -quit 2>/dev/null)"
+        if [[ -n $produced ]]; then
+            mv -- "$produced" "$target"
+        fi
+    fi
+    if [[ ! -f $target ]]; then
+        echo "UltraStarFox build did not produce $name" >&2
+        exit 1
+    fi
+    ls -l -- "$target"
+done

--- a/tools/test_runtime_matrix.sh
+++ b/tools/test_runtime_matrix.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+project_root="$(cd -- "$script_dir/.." && pwd)"
+executable="${1:-$project_root/build/release/starfox_pc}"
+sample_seconds="${2:-0.6}"
+minimum_ratio="${3:-0.70}"
+
+if [[ ! -x $executable ]]; then
+    echo "Runtime executable not found at $executable" >&2
+    exit 1
+fi
+
+rates=(20 30 60 90 120 240 360 480)
+displays=(0 1 2 3 4)
+paces=(UNLOCKED ORIGINAL)
+
+printf '%-8s %-6s %-9s %-9s %-7s %s\n' \
+    DISPLAY FPS PACE MEASURED RATIO RESULT
+failures=0
+combinations=0
+
+for display in "${displays[@]}"; do
+    for rate in "${rates[@]}"; do
+        for pace in "${paces[@]}"; do
+            frames="$(awk -v rate="$rate" -v sample="$sample_seconds" \
+                'BEGIN { frames = int(rate * sample); \
+                    if (frames < rate * sample) frames += 1; \
+                    if (frames < 12) frames = 12; print frames }')"
+            set +e
+            error_text="$(
+                STARFOX_TEST_FRAMES="$frames" \
+                STARFOX_TEST_SKIP_PREROLL=1 \
+                STARFOX_TEST_PRESENTATION_FPS="$rate" \
+                STARFOX_TEST_DISPLAY_MODE="$display" \
+                STARFOX_TEST_TIMING_MODE="$pace" \
+                STARFOX_TRACE_FPS=1 \
+                "$executable" 2>&1 >/dev/null
+            )"
+            status=$?
+            set -e
+            if [[ $status -ne 0 ]]; then
+                echo "Matrix run failed for display=$display fps=$rate pace=$pace" >&2
+                echo "$error_text" >&2
+                exit 1
+            fi
+            measured="$(sed -n 's/.*measured=\([0-9][0-9]*\).*/\1/p' \
+                <<<"$error_text" | tail -n 1)"
+            if [[ -z $measured ]]; then
+                echo "Matrix run did not report FPS for display=$display fps=$rate pace=$pace" >&2
+                echo "$error_text" >&2
+                exit 1
+            fi
+            ratio="$(awk -v measured="$measured" -v rate="$rate" \
+                'BEGIN { printf "%.3f", measured / rate }')"
+            if awk -v ratio="$ratio" -v measured="$measured" \
+                -v minimum="$minimum_ratio" \
+                'BEGIN { exit !(measured > 0 && ratio >= minimum) }'; then
+                result=PASS
+            else
+                result=FAIL
+                failures=$((failures + 1))
+            fi
+            combinations=$((combinations + 1))
+            printf '%-8s %-6s %-9s %-9s %-7s %s\n' \
+                "$display" "$rate" "$pace" "$measured" "$ratio" "$result"
+        done
+    done
+done
+
+if [[ $failures -ne 0 ]]; then
+    echo "$failures runtime timing combinations were stuck or unexpectedly low" >&2
+    exit 1
+fi
+echo "Validated $combinations resolution/FPS/pace combinations."


### PR DESCRIPTION
The game only built on Windows. This makes it build and run on Linux too.

Most of the work is the packed data. On Windows the patch files and symbol lists are packed inside the program using a Windows-only tool. Linux now packs the same files its own way, so both versions carry identical data. The way the program looks that data up is unchanged, so the checks that confirm the data is intact didn't need touching.

The rest is smaller pieces: finding your cartridge file and settings folder in the usual Linux places, stopping a second copy of the game from running, working out where the program lives on disk so its data file lands beside it, and showing the start-up error box through SDL, which behaves the same on both systems.

I've also added play-starfox.sh and the two build scripts, matching the PowerShell ones already there. They drive DOSBox-X the way the UltraStarFox project's own Linux makefile does. One thing worth knowing: DOS writes its output file names in a different capitalisation than the project expects, which Windows ignores but Linux does not, so the scripts correct it.

One change here affects Windows as well. The build didn't watch the packed files, so rebuilding the cartridge could leave the program carrying old data until you cleaned the build folder. Neither the Windows tool nor the Linux one reports which files it read, so I added that tracking. It's a fix on both systems.

Tested on Fedora 44 with GCC.